### PR TITLE
Optimize our requires

### DIFF
--- a/bin/community-zero
+++ b/bin/community-zero
@@ -7,7 +7,7 @@ $:.unshift(File.dirname(__FILE__) + '../lib')
 Signal.trap('INT') { exit 1 }
 
 require 'community_zero'
-require 'optparse'
+require 'optparse' unless defined?(OptionParser)
 
 options = { :publish => true }
 

--- a/lib/community_zero.rb
+++ b/lib/community_zero.rb
@@ -15,8 +15,8 @@
 # limitations under the License.
 #
 
-require 'json'
-require 'timeout'
+require 'json' unless defined?(JSON)
+require 'timeout' unless defined?(Timeout)
 
 module CommunityZero
   require_relative 'community_zero/chef'

--- a/lib/community_zero/chef/metadata.rb
+++ b/lib/community_zero/chef/metadata.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require 'json'
+require 'json' unless defined?(JSON)
 
 module CommunityZero
   # A quick, short metadata parser.

--- a/lib/community_zero/endpoints/cookbooks_endpoint.rb
+++ b/lib/community_zero/endpoints/cookbooks_endpoint.rb
@@ -20,8 +20,8 @@ module CommunityZero
   #
   # @author Seth Vargo <sethvargo@gmail.com>
   class CookbooksEndpoint < Endpoint
-    require 'rubygems/package'
-    require 'zlib'
+    require 'rubygems/package' unless defined?(Gem::Package)
+    require 'zlib' unless defined?(Zlib)
 
     # GET /cookbooks
     def get(request)

--- a/lib/community_zero/rspec.rb
+++ b/lib/community_zero/rspec.rb
@@ -1,5 +1,5 @@
-require 'net/http'
-require 'singleton'
+require 'net/http' unless defined?(Net::HTTP)
+require 'singleton' unless defined?(Singleton)
 
 require_relative 'server'
 

--- a/lib/community_zero/server.rb
+++ b/lib/community_zero/server.rb
@@ -15,9 +15,9 @@
 # limitations under the License.
 #
 
-require 'open-uri'
-require 'rack'
-require 'webrick'
+require 'open-uri' unless defined?(OpenURI)
+require 'rack' unless defined?(Rack)
+require 'webrick' unless defined?(WEBrick)
 
 require_relative '../community_zero'
 


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>